### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,6 +18,16 @@ class ProductsController < ApplicationController
     end
   end
 
+  def show
+    @user = User.all
+    @product = Product.find(params[:id])
+    @category = Category.data
+    @condition = Condition.data
+    @delivery_charge = DeliveryCharge.data
+    @delivery_source = DeliverySource.data
+    @days_to_ship = DaysToShip.data
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,13 +19,7 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @user = User.all
     @product = Product.find(params[:id])
-    @category = Category.data
-    @condition = Condition.data
-    @delivery_charge = DeliveryCharge.data
-    @delivery_source = DeliverySource.data
-    @days_to_ship = DaysToShip.data
   end
 
   private

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,7 +128,7 @@
       <%# 商品がある場合、一覧を表示する処理 %>
       <% @products.each do |product|%>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to product_path(product) do %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -105,7 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,54 +16,57 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @product.price%>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        (税込) <%= @delivery_charge[@product.delivery_charge_id - 1][:charge]%>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# 購入・編集・削除の表示を分ける処理 %>
+    <%# ログイン中のユーザーと出品したユーザが同じ場合 %>
+    <% if user_signed_in? && current_user.id == @product.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%# //ログイン中のユーザーと出品したユーザが同じ場合 %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# 商品が売れていない場合 %>
+    <% elsif user_signed_in? %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# //商品が売れていない場合 %>
+    <% end %>
+    
+    <%# //購入・編集・削除の表示を分ける処理 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @user[@product.user_id - 1 ].nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @category[@product.category_id - 1 ][:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @condition[@product.condition_id - 1 ][:condition] %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @delivery_charge[@product.delivery_charge_id - 1 ][:charge] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @delivery_source[@product.delivery_source_id - 1 ][:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @days_to_ship[@product.days_to_ship_id - 1 ][:days] %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -19,7 +19,7 @@
         ¥<%= @product.price%>
       </span>
       <span class="item-postage">
-        (税込) <%= @delivery_charge[@product.delivery_charge_id - 1][:charge]%>
+        (税込) <%= @product.delivery_charge.charge %>
       </span>
     </div>
 
@@ -46,27 +46,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @user[@product.user_id - 1 ].nickname %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @category[@product.category_id - 1 ][:name] %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @condition[@product.condition_id - 1 ][:condition] %></td>
+          <td class="detail-value"><%= @product.condition.condition %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @delivery_charge[@product.delivery_charge_id - 1 ][:charge] %></td>
+          <td class="detail-value"><%= @product.delivery_charge.charge %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @delivery_source[@product.delivery_source_id - 1 ][:name] %></td>
+          <td class="detail-value"><%= @product.delivery_source.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @days_to_ship[@product.days_to_ship_id - 1 ][:days] %></td>
+          <td class="detail-value"><%= @product.days_to_ship.days %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# WHAT
商品詳細表示機能を実装しましたのでご確認お願いします！
動作の様子を一緒に添付します。

ログアウトした状態でも詳細をみることができる
ログアウトした状態だと購入や編集・削除することができない：
https://gyazo.com/baf49ea69b5c18c65c4fd8d3cfa78a09

ログイン中のユーザーと、出品したユーザーが同じなら
商品の編集・削除がビューに表示される：
https://gyazo.com/021a5207da41c3200c315e989eff329f

ログイン中のユーザーと、出品したユーザーが異なるなら
購入画面が表示される：
https://gyazo.com/38fe5803e4dc079cb3a84d50e6e45ff5

# WHY
いくつか共有事項がございます。

- アクティブハッシュを使っている箇所（状態や配送料の負担など）を表示する際は
アクティブハッシュのデータを取得し、表示させるように処理しています。

- 出品者のみ商品の編集と削除のリンクを踏めるようにする際、現時点ではリダイレクトを設定していません。
理由としては以下の２点です。
①まだ編集削除の機能を実装していないこと。
②編集削除機能を実装した上で、リダイレクトを設定した方が管理しやすいと考えたため

以上、よろしくお願いします！
